### PR TITLE
Remove dependency on JS for the domain list

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,6 @@ export default defineConfig({
 	site: 'https://erisa.uk',
 	integrations: [mdx()],
 	build: {
-		format: 'file'
-	}
+		format: 'file',
+	},
 });

--- a/functions/cf.json.js
+++ b/functions/cf.json.js
@@ -1,3 +1,3 @@
-export function onRequestGet({request}) {
-  return Response.json(request.cf)
+export function onRequestGet({ request }) {
+	return Response.json(request.cf);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@astrojs/mdx": "^0.14.0",
 				"@fontsource/inter": "^4.5.14",
+				"@types/node": "^18.11.18",
 				"astro": "^1.9.2"
 			},
 			"devDependencies": {
@@ -878,11 +879,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.45",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-			"integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-			"optional": true,
-			"peer": true
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 		},
 		"node_modules/@types/parse5": {
 			"version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@astrojs/mdx": "^0.14.0",
 		"@fontsource/inter": "^4.5.14",
+		"@types/node": "^18.11.18",
 		"astro": "^1.9.2"
 	},
 	"devDependencies": {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -16,9 +16,8 @@ const {
 	image = 'https://cdn.erisa.uk/avatars/common.png',
 } = Astro.props;
 
-let astroUrl = Astro.url
-astroUrl.pathname = astroUrl.pathname.replace('.html', '')
-
+let astroUrl = Astro.url;
+astroUrl.pathname = astroUrl.pathname.replace('.html', '');
 ---
 
 <!--

--- a/src/components/DomainList.astro
+++ b/src/components/DomainList.astro
@@ -1,15 +1,16 @@
-<p id="domains">
-	Loading.. If it doesn't load or you have JavaScript disabled,
-	<a href="domains.txt">click here.</a>. Sorry for the trouble!
-</p>
+---
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'url';
 
-<script>
-	fetch('/domains.txt')
-		.then(function (response) {
-			return response.text();
-		})
-		.then(function (domains) {
-			const element: HTMLElement | null = document.getElementById('domains');
-			if (element !== null) element.innerText = domains;
-		});
-</script>
+const IS_PRODUCTION = import.meta.env.MODE === 'production';
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const domains = await readFile(
+	join(path, `${IS_PRODUCTION ? '../../domains.txt' : '../../public/domains.txt'}`),
+	'utf-8'
+);
+---
+
+<p id="domains">{domains}</p>

--- a/src/components/DomainList.astro
+++ b/src/components/DomainList.astro
@@ -8,7 +8,7 @@ const IS_PRODUCTION = import.meta.env.MODE === 'production';
 const path = dirname(fileURLToPath(import.meta.url));
 
 const domains = await readFile(
-	join(path, `${IS_PRODUCTION ? '../../domains.txt' : '../../public/domains.txt'}`),
+	join(path, `${IS_PRODUCTION ? '/domains.txt' : '../../public/domains.txt'}`),
 	'utf-8'
 );
 ---

--- a/src/pages/domains.mdx
+++ b/src/pages/domains.mdx
@@ -10,7 +10,8 @@ import DomainList from '../components/DomainList.astro';
 
 # Erisa's domain list
 
-This list is designed to be machine readable.  
-You can find the raw text file [here](/domains.txt).
+This list is designed to be machine readable.
+
+You can find the raw text file [here](/domains.txt) if it doesn't load for you. Sorry for the trouble!
 
 <DomainList />

--- a/src/pages/domains.mdx
+++ b/src/pages/domains.mdx
@@ -10,8 +10,7 @@ import DomainList from '../components/DomainList.astro';
 
 # Erisa's domain list
 
-This list is designed to be machine readable.
-
-You can find the raw text file [here](/domains.txt) if it doesn't load for you. Sorry for the trouble!
+This list is designed to be machine readable.  
+You can find the raw text file [here](/domains.txt).
 
 <DomainList />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,6 +16,7 @@ body {
 #domains {
 	font-size: 14px;
 	background-color: #f1f1f1;
+	white-space: pre;
 }
 
 a {


### PR DESCRIPTION
This removes dependency on JavaScript for the domain list, and instead utilizes base Node libraries (fs, path, url) to load the text file.

Let me know if I should change anything.